### PR TITLE
Fixed fatal'ing empty() calls on PHP < 5.5

### DIFF
--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -18,7 +18,9 @@ class BackupCommand extends BaseCommand
     {
         $databaseName = Config::get('database.default', false);
 
-        if ( ! empty($this->input->getOption('database'))) {
+	    $databaseOption = $this->input->getOption('database');
+
+        if ( ! empty($databaseOption)) {
             $databaseName = $this->input->getOption('database');
         }
 
@@ -87,7 +89,8 @@ class BackupCommand extends BaseCommand
 
             $databaseConnectionConfig = Config::get('database.connections.' . $this->input->getOption('database'));
             if ( ! empty($databaseConnectionConfig['slackToken']) && ! empty($databaseConnectionConfig['slackSubDomain'])) {
-                $disableSlack = ! empty($this->option('disable-slack'));
+	            $disableSlackOption = $this->option('disable-slack');
+                $disableSlack = ! empty($disableSlackOption);
                 if ( ! $this->option('disable-slack')) $this->notifySlack($databaseConnectionConfig);
             }
 


### PR DESCRIPTION
The composer.json says PHP 5.4 should work, so I think this issue should be considered a bug or the composer.json's php requirement needs to be bumped up to 5.5.

From the PHP manual:

```
Note: Prior to PHP 5.5, empty() only supports variables; anything else will result in a parse error. In other words, the following will not work: empty(trim($name)). Instead, use trim($name) == false.
```

So after installing laravel-db-backup, my php artisan command fatals out:

```
lamoni@testServer:$ php artisan
PHP Fatal error:  Can't use method return value in write context in /var/www/vendor/coreproc/laravel-db-backup/src/Commands/BackupCommand.php on line 21
{"error":{"type":"Symfony\\Component\\Debug\\Exception\\FatalErrorException","message":"Can't use method return value in write context","file":"\/var\/www\/vendor\/coreproc\/laravel-db-backup\/src\/Commands\/BackupCommand.php","line":21}}
```

This is due to the passing of functions to empty() calls, found on line 21 and line 90 in BackupCommand.php:

``` php
        if ( ! empty($this->input->getOption('database'))) {
            $databaseName = $this->input->getOption('database');
        }
       ......

        $disableSlack = ! empty($this->option('disable-slack'));
```

To fix this issue, we need to assign variables with the results of the function, and then pass those to empty() instead. E.g.:

``` php
        $databaseOption = $this->input->getOption('database');

        if ( ! empty($databaseOption)) {
            $databaseName = $this->input->getOption('database');
        }
```
